### PR TITLE
Resolve GoReleaser deprecation: rename snapshot.name_template to version_template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
https://goreleaser.com/deprecations/#snapshotname_template