### PR TITLE
Configure golangci-lint with v2 formatters and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
       - name: Build
         run: |
           go build

--- a/config_test.go
+++ b/config_test.go
@@ -9,11 +9,7 @@ import (
 
 func TestReadConfig_EnvVars(t *testing.T) {
 	// Create a temporary directory for config files
-	tmpDir, err := os.MkdirTemp("", "cronlog-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "cronlog.toml")
 	configContent := `

--- a/slack.go
+++ b/slack.go
@@ -47,7 +47,7 @@ func PostToSlack(text string, attributes map[string]string, slackConfig SlackCon
 	)
 
 	body, _ := io.ReadAll(resp.Body)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return string(body)
 }


### PR DESCRIPTION
We need golangci-lint.